### PR TITLE
Make it so that, when skipping, the volume doesn't jump up for a little bit

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -205,7 +205,7 @@ export class Track {
     this.#sound.onended = () => this.#onSoundEnded();
 
     this.#gain = this.#audioContext.createGain();
-    this.#applyGainParams();
+    this.#applyGainParams(true);
 
     this.#sound.connect(this.#gain);
     this.#gain.connect(this.#audioContext.destination);
@@ -256,7 +256,7 @@ export class Track {
     this.stop(true);
   }
 
-  #applyGainParams() {
+  #applyGainParams(instant = false) {
     if (!this.#gain) {
       return;
     }
@@ -267,7 +267,7 @@ export class Track {
       return;
     }
 
-    if (this.#playState === PLAY_STATE.started) {
+    if (this.#playState === PLAY_STATE.started && !instant) {
       // To avoid ugly clicking during playback when adjusting the volume
       // we have to switch to the new volume gradually (sample by sample):
       this.#gain.gain.setTargetAtTime(actualValue, this.#audioContext.currentTime, GAIN_DECAY_DURATION);


### PR DESCRIPTION
There was a problem where, for example, if a track is muted and the player is playing, when you skip, you hear a bit of the track. 
This was because, when Track.start is called, it creates a new gain node (which then has a volume of 1) and then uses Track.applyGainParams is used to set the volume, which then fades the volume from 1 to 0.

In this pr, i chose to fix it by giving applyGainParams an optional parameter `instant`, which is only set to true when called from start.
Alternatively, you could probably choose to not create a new gain node in start if one already exists, i think.
